### PR TITLE
Fix Dockerfile

### DIFF
--- a/iot-agent/Dockerfile
+++ b/iot-agent/Dockerfile
@@ -96,8 +96,7 @@ RUN \
 	# Remove Git and clean apt cache
 	apt-get clean && \
 	apt-get remove -y git && \
-	apt-get -y autoremove && \
-	chmod +x docker/entrypoint.sh
+	apt-get -y autoremove
 
 USER node
 ENV NODE_ENV=production
@@ -105,5 +104,6 @@ ENV NODE_ENV=production
 # Expose 4061 for NORTH PORT, 7896 for HTTP PORT
 EXPOSE ${IOTA_NORTH_PORT:-4061} ${IOTA_HTTP_PORT:-7896}
 
-ENTRYPOINT ["docker/entrypoint.sh"]
-CMD ["-- ", "config.js"]
+CMD ["node", "/opt/iotaul/bin/iotagent-ul", "-- ", "config.js"]
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s \
+   CMD ["npm", "run", "healthcheck"]


### PR DESCRIPTION
This PR fixes the failure to build the docker image for `iot-agent` in the NGSI-LD branch.

```
$ ./services orion
...
chmod: cannot access 'docker/entrypoint.sh': No such file or directory
ERROR: Service 'iot-agent' failed to build: The command '/bin/sh -c apt-get update &&   apt-get install -y git &&       npm install pm2@3.2.2 -g &&       echo "INFO: npm install --production..." &&     npm install --production &&     apt-get clean &&        apt-get remove -y git &&        apt-get -y autoremove &&  chmod +x docker/entrypoint.sh' returned a non-zero code: 1
```