### PR TITLE
FIX checking for number of arguments

### DIFF
--- a/services
+++ b/services
@@ -7,7 +7,7 @@
 set -e
 
 dockerCmd="docker compose"
-if (( $# == 2 )); then
+if (( $# == 1 )); then
     dockerCmd="docker-compose"
 fi
 


### PR DESCRIPTION
FIX service script when checking the number of arguments as it expects one argument.

I guess this should apply to every tutorial